### PR TITLE
Make ServerConfiguration interface consistent

### DIFF
--- a/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/GeoWebCacheConfiguration.java
@@ -310,7 +310,7 @@ public class GeoWebCacheConfiguration {
 
     /**
      * Get the FullWMS value if present
-     * @see ServerConfiguration#getfullWMS()
+     * @see ServerConfiguration#isFullWMS()
      * @return TRUE, FALSE, or NULL
      */
     public Boolean getFullWMS() {
@@ -319,7 +319,7 @@ public class GeoWebCacheConfiguration {
 
     /**
      * Set the FullWMS value if present
-     * @see ServerConfiguration#setFullWMS(boolean)
+     * @see ServerConfiguration#setFullWMS(Boolean)
      * @param fullWMS is true or false
      */
     public void setFullWMS(Boolean fullWMS) {

--- a/geowebcache/core/src/main/java/org/geowebcache/config/ServerConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/ServerConfiguration.java
@@ -24,13 +24,13 @@ public interface ServerConfiguration extends BaseConfiguration {
      * been serving in the past 3, 15 and 60 seconds, as well as aggregate numbers.
      * @return True or False if disabled
      */
-    boolean isRuntimeStatsEnabled();
+    Boolean isRuntimeStatsEnabled();
 
     /**
      * Set if runtime statistics is enabled for this configuration, True or False.
      * @param isEnabled
      */
-    void setIsRuntimeStatsEnabled(boolean isEnabled) throws IOException;
+    void setRuntimeStatsEnabled(Boolean isEnabled) throws IOException;
 
     /**
      * The name of the lock provider.
@@ -48,13 +48,13 @@ public interface ServerConfiguration extends BaseConfiguration {
      * Used for getting the "fullWMS" parameter from GeoWebCacheConfigration if present
      * @return True, False or Null if not present
      */
-    Boolean getfullWMS();
+    Boolean isFullWMS();
 
     /**
      * Used to set fullWMS is parameter for this configuration if present.
      * @param isFullWMS
      */
-    void setFullWMS(boolean isFullWMS) throws IOException;
+    void setFullWMS(Boolean isFullWMS) throws IOException;
 
     /**
      * If this method returns NULL CITE strict compliance mode should not be considered for WMTS
@@ -62,7 +62,7 @@ public interface ServerConfiguration extends BaseConfiguration {
      *
      * @return may return TRUE, FALSE or NULL
      */
-    boolean isWmtsCiteCompliant();
+    Boolean isWmtsCiteCompliant();
 
     /**
      * Can be used to force WMTS service implementation to be strictly compliant with the
@@ -71,7 +71,7 @@ public interface ServerConfiguration extends BaseConfiguration {
      * @param wmtsCiteStrictCompliant TRUE or FALSE, activating or deactivation CITE
      *                                strict compliance mode for WMTS
      */
-    void setWmtsCiteStrictCompliant(boolean wmtsCiteStrictCompliant) throws IOException;
+    void setWmtsCiteCompliant(Boolean wmtsCiteStrictCompliant) throws IOException;
 
     /**
      * The backend timeout is the number of seconds GWC will wait for a backend server to return something
@@ -92,7 +92,7 @@ public interface ServerConfiguration extends BaseConfiguration {
      *  including converters such as Google Maps.
      * @return True or False
      */
-    Boolean getCacheBypassAllowed();
+    Boolean isCacheBypassAllowed();
 
     /**
      *

--- a/geowebcache/core/src/main/java/org/geowebcache/config/TileLayerConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/TileLayerConfiguration.java
@@ -156,17 +156,6 @@ public interface TileLayerConfiguration extends BaseConfiguration {
     boolean containsLayer(String layerName);
 
     /**
-     * If this method returns TRUE WMTS service implementation will strictly comply with the
-     * correspondent CITE tests.
-     *
-     * @return TRUE or FALSE, activating or deactivation CITE strict compliance mode for WMTS
-     */
-    default boolean isWmtsCiteCompliant() {
-        // by default CITE tests strict compliance is not activated
-        return false;
-    }
-
-    /**
      * Whether the configuration is capable of saving the provided tile layer.
      *
      * @param tl a tile layer to be added or saved

--- a/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
+++ b/geowebcache/core/src/main/java/org/geowebcache/config/XMLConfiguration.java
@@ -300,7 +300,7 @@ public class XMLConfiguration implements TileLayerConfiguration, InitializingBea
     /**
      * @see ServerConfiguration#isRuntimeStatsEnabled()
      */
-    public boolean isRuntimeStatsEnabled() {
+    public Boolean isRuntimeStatsEnabled() {
         if (getGwcConfig() == null || getGwcConfig().getRuntimeStats() == null) {
             return true;
         } else {
@@ -309,10 +309,10 @@ public class XMLConfiguration implements TileLayerConfiguration, InitializingBea
     }
 
     /**
-     * @see ServerConfiguration#setIsRuntimeStatsEnabled(boolean)
+     * @see ServerConfiguration#setRuntimeStatsEnabled(Boolean)
      * @param isEnabled
      */
-    public void setIsRuntimeStatsEnabled(boolean isEnabled) throws IOException {
+    public void setRuntimeStatsEnabled(Boolean isEnabled) throws IOException {
         getGwcConfig().setRuntimeStats(isEnabled);
         save();
     }
@@ -1104,10 +1104,10 @@ public class XMLConfiguration implements TileLayerConfiguration, InitializingBea
     }
 
     /**
-     * @see ServerConfiguration#getfullWMS()
+     * @see ServerConfiguration#isFullWMS()
      */
     @Override
-    public Boolean getfullWMS(){
+    public Boolean isFullWMS(){
         if(getGwcConfig()!=null){
             return getGwcConfig().getFullWMS();
         }
@@ -1115,11 +1115,11 @@ public class XMLConfiguration implements TileLayerConfiguration, InitializingBea
     }
 
     /**
-     * @see ServerConfiguration#setFullWMS(boolean)
+     * @see ServerConfiguration#setFullWMS(Boolean)
      * @param isFullWMS
      */
     @Override
-    public void setFullWMS(boolean isFullWMS) throws IOException {
+    public void setFullWMS(Boolean isFullWMS) throws IOException {
         getGwcConfig().setFullWMS(isFullWMS);
         save();
     }
@@ -1370,7 +1370,7 @@ public class XMLConfiguration implements TileLayerConfiguration, InitializingBea
     }
 
     @Override
-    public boolean isWmtsCiteCompliant() {
+    public Boolean isWmtsCiteCompliant() {
         if (gwcConfig == null) {
             // if there is not configuration available we consider CITE strict compliance to be deactivated
             return false;
@@ -1386,7 +1386,7 @@ public class XMLConfiguration implements TileLayerConfiguration, InitializingBea
      * @param wmtsCiteStrictCompliant TRUE or FALSE, activating or deactivation CITE
      *                                strict compliance mode for WMTS
      */
-    public void setWmtsCiteStrictCompliant(boolean wmtsCiteStrictCompliant) throws IOException {
+    public void setWmtsCiteCompliant(Boolean wmtsCiteStrictCompliant) throws IOException {
         if (gwcConfig != null) {
             // activate or deactivate CITE strict compliance mode for WMTS implementation
             gwcConfig.setWmtsCiteCompliant(wmtsCiteStrictCompliant);
@@ -1412,10 +1412,10 @@ public class XMLConfiguration implements TileLayerConfiguration, InitializingBea
     }
 
     /**
-     * @see ServerConfiguration#getCacheBypassAllowed()
+     * @see ServerConfiguration#isCacheBypassAllowed()
      */
     @Override
-    public Boolean getCacheBypassAllowed() {
+    public Boolean isCacheBypassAllowed() {
         return gwcConfig.getCacheBypassAllowed();
     }
 

--- a/geowebcache/core/src/test/java/org/geowebcache/config/ServerConfigurationTest.java
+++ b/geowebcache/core/src/test/java/org/geowebcache/config/ServerConfigurationTest.java
@@ -39,29 +39,29 @@ public class ServerConfigurationTest {
 
         Boolean runtimeStats = config.isRuntimeStatsEnabled();
         assertTrue(runtimeStats);
-        config.setIsRuntimeStatsEnabled(false);
+        config.setRuntimeStatsEnabled(false);
         runtimeStats = config.isRuntimeStatsEnabled();
         assertFalse(runtimeStats);
 
         LockProvider lockProvider = config.getLockProvider();
         assertNotNull(lockProvider);
 
-        Boolean fullWMS = config.getfullWMS();
+        Boolean fullWMS = config.isFullWMS();
         assertNull(fullWMS);
         config.setFullWMS(true);
-        fullWMS = config.getfullWMS();
+        fullWMS = config.isFullWMS();
         assertTrue(fullWMS);
 
         Boolean wmtsCiteCompliant = config.isWmtsCiteCompliant();
         assertFalse(wmtsCiteCompliant);
-        config.setWmtsCiteStrictCompliant(true);
+        config.setWmtsCiteCompliant(true);
         wmtsCiteCompliant = config.isWmtsCiteCompliant();
         assertTrue(wmtsCiteCompliant);
 
-        Boolean cacheBypassAllowed = config.getCacheBypassAllowed();
+        Boolean cacheBypassAllowed = config.isCacheBypassAllowed();
         assertNull(cacheBypassAllowed);
         config.setCacheBypassAllowed(true);
-        cacheBypassAllowed = config.getCacheBypassAllowed();
+        cacheBypassAllowed = config.isCacheBypassAllowed();
         assertTrue(cacheBypassAllowed);
 
         Integer backendTimeout = config.getBackendTimeout();
@@ -78,9 +78,9 @@ public class ServerConfigurationTest {
         ServiceInformation savedInfo = config.getServiceInformation();
         assertEquals(savedInfo.getProviderName(), "John Adams inc.");
         assertFalse(config.isRuntimeStatsEnabled());
-        assertTrue(config.getfullWMS());
+        assertTrue(config.isFullWMS());
         assertTrue((config.isWmtsCiteCompliant()));
-        assertTrue(config.getCacheBypassAllowed());
+        assertTrue(config.isCacheBypassAllowed());
         assertEquals(config.getBackendTimeout(), (Integer) 60);
         assertEquals(config.getVersion(), "1.13.0");
     }

--- a/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
+++ b/geowebcache/wms/src/main/java/org/geowebcache/service/wms/WMSService.java
@@ -433,7 +433,7 @@ public class WMSService extends Service{
         // From the configuration file the "fullWMS" parameter is searched
         Boolean wmsFull = null;
         if(gwcXMLconfig!=null){
-            wmsFull = gwcXMLconfig.getfullWMS();
+            wmsFull = gwcXMLconfig.isFullWMS();
         }                
         
         if(wmsFull!=null){

--- a/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSService.java
+++ b/geowebcache/wmts/src/main/java/org/geowebcache/service/wmts/WMTSService.java
@@ -20,6 +20,7 @@ package org.geowebcache.service.wmts;
 import org.geowebcache.GeoWebCacheDispatcher;
 import org.geowebcache.GeoWebCacheException;
 import org.geowebcache.GeoWebCacheExtensions;
+import org.geowebcache.config.ServerConfiguration;
 import org.geowebcache.config.TileLayerConfiguration;
 import org.geowebcache.conveyor.Conveyor;
 import org.geowebcache.conveyor.ConveyorTile;
@@ -75,7 +76,7 @@ public class WMTSService extends Service  {
     
     private GeoWebCacheDispatcher controller = null;
 
-    private TileLayerConfiguration mainConfiguration;
+    private ServerConfiguration mainConfiguration;
 
     // list of this service extensions ordered by their priority
     private final List<WMTSExtension> extensions = new ArrayList<>();
@@ -407,7 +408,7 @@ public class WMTSService extends Service  {
      *
      * @param mainConfiguration GWC main configuration
      */
-    public void setMainConfiguration(TileLayerConfiguration mainConfiguration) {
+    public void setMainConfiguration(ServerConfiguration mainConfiguration) {
         this.mainConfiguration = mainConfiguration;
     }
 


### PR DESCRIPTION
All methods return `Boolean`; previously a mix of `Boolean` and `boolean`
All methods which return `Boolean` use "is" for getters; previously a mix of "is" and "get".

Removed `isWmtsCiteCompliant` from `TileLayerConfiguration`, as it had already been moved to `ServerConfiguration`.